### PR TITLE
Fix issue with some calls are very long

### DIFF
--- a/etc/nginx/locations/https-available/asterisk
+++ b/etc/nginx/locations/https-available/asterisk
@@ -3,9 +3,9 @@ location = /api/asterisk/ws {
         return 403;
     }
 
-    proxy_pass https://127.0.0.1:5040/ws;
+    proxy_pass http://127.0.0.1:5039/ws;
     proxy_http_version 1.1;
-    proxy_read_timeout 1d;
+    proxy_read_timeout 90s;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
 }


### PR DESCRIPTION
Sometimes on webrtc we have some calls who are very long. After some research we find there is an issue with the buffer size on ssl termination  with nginx. This issue is not present with apache, but in fact we don't need to have an ssl termination between asterisk and nginx by default. So just change the configuration to use the asterisk http endpoint instead https fix this issue.