### PR TITLE
voicemail: on destination voicemail do not ignore the options

### DIFF
--- a/dialplan/asterisk/extensions_lib_vmbox.conf
+++ b/dialplan/asterisk/extensions_lib_vmbox.conf
@@ -1,6 +1,4 @@
-; XIVO Dialplan
-; Copyright (C) 2006-2014  Avencall
-; Copyright (C) 2016 Proformatique Inc.
+; Copyright 2006-2019 The Wazo Authors  (see the AUTHORS file)
 ; SPDX-License-Identifier: GPL-2.0+
 
 ; params:
@@ -13,7 +11,8 @@ same  =   n,Set(XIVO_VMBOXID=${ARG1})
 same  =   n,AGI(agi://${XIVO_AGID_IP}/vmbox_get_info)
 same  =   n,Gosub(xivo-pickup,0,1)
 same  =   n,Set(TIMEOUT(absolute)=1800)
-same  =   n,Set(XIVO_MAILBOX_OPTIONS=${IF($["${FILTER(u,${ARG2})}" = "u"]?${REPLACE(ARG2,u,)}:u${ARG2})})
+same  =   n,Set(XIVO_MAILBOX_OPTIONS=${IF($["${FILTER(u,${ARG2})}" = "u"]?u:${XIVO_MAILBOX_OPTIONS})})
+same  =   n,Set(XIVO_MAILBOX_OPTIONS=${IF($["${FILTER(b,${ARG2})}" = "b"]?b:${XIVO_MAILBOX_OPTIONS})})
 same  =   n,GotoIf($["${XIVO_MAILBOX_LANGUAGE}" = ""]?$[${PRIORITY} + 2])
 same  =   n,Set(CHANNEL(language)=${XIVO_MAILBOX_LANGUAGE})
 same  =   n,VoiceMail(${XIVO_MAILBOX}@${XIVO_MAILBOX_CONTEXT},${XIVO_MAILBOX_OPTIONS})


### PR DESCRIPTION
In this context ARG2 contains options for the Voicemail application. The
possible values are "b" and "u" which are mutually exclusive.

When "b" is used the message indicates that the user is busy.
When "u" is used the message indicates that the user is unavailable.
When none of the above is set the we are invited to leave a message.

So, whats happening here.

FILTER(u,$(ARGS)) will return "u" if ARG2 contains "u" ex: "busy" ==> "u"
The IF will match the "u" and set the XIVO_MAILBOX_OPTIONS to "u"

Since "b" is mutually exclusive with "u" we can safely overrite the previous
value if "b" is set.