### PR TITLE
WAZO-1610: manage slave service: stop restart wazo-auth

### DIFF
--- a/sbin/xivo-manage-slave-services
+++ b/sbin/xivo-manage-slave-services
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
@@ -37,7 +37,6 @@ stop_dhcp() {
 }
 
 enable_service() {
-    systemctl restart wazo-auth
     start_dhcp
     set_berofos_to_slave_state
     wazo-confgen asterisk/pjsip.conf --invalidate


### PR DESCRIPTION
wazo-auth was restarted to re-generate the tenant tree cache on the slave. The
cache has been removed.

Depends-On: https://github.com/wazo-platform/wazo-auth/pull/71