### PR TITLE
mobile: allow uppercase characters in SIP line name

### DIFF
--- a/dialplan/asterisk/extensions_lib_user.conf
+++ b/dialplan/asterisk/extensions_lib_user.conf
@@ -1,4 +1,4 @@
-; Copyright 2006-2019 The Wazo Authors  (see the AUTHORS file)
+; Copyright 2006-2020 The Wazo Authors  (see the AUTHORS file)
 ; SPDX-License-Identifier: GPL-2.0+
 
 ; params:
@@ -227,6 +227,6 @@ same  = n,Dial(${WAZO_USER_INTERFACES})
 same  = n,Hangup
 
 [wazo_wait_for_registration]
-exten = _[0-9a-z].,1,NoOp(Waiting for ${EXTEN})
+exten = _[0-9A-Za-z].,1,NoOp(Waiting for ${EXTEN})
 same  = n,Stasis(dial_mobile,dial,${EXTEN})
 same  = n,Hangup()


### PR DESCRIPTION
Why:

* If a mobile app is registered with a SIP line with uppercase characters
and receives a call, the dialplan stops.