### PR TITLE
extensions_lib_user: simplify usersharedlines

### DIFF
--- a/dialplan/asterisk/extensions_lib_user.conf
+++ b/dialplan/asterisk/extensions_lib_user.conf
@@ -221,8 +221,8 @@ same  =      n,Playback(noright)
 same  =      n,Hangup()
 
 [usersharedlines]
-; 32 [0-9a-f] is too long and - are ignored
-exten = _[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f].,1,AGI(agi://${XIVO_AGID_IP}/get_user_interfaces,${EXTEN})
+; exten should be a user UUID
+exten = _[0-9a-f].,1,AGI(agi://${XIVO_AGID_IP}/get_user_interfaces,${EXTEN})
 same  = n,Dial(${WAZO_USER_INTERFACES})
 same  = n,Hangup
 


### PR DESCRIPTION
Why:

* The pattern is very hard to read and does not bring any value, since
the AGI already checks if the UUID is valid.