### PR TITLE
Pull request for WAZO-1915-adhoc-conference-events

### DIFF
--- a/dialplan/asterisk/extensions_lib_stasis.conf
+++ b/dialplan/asterisk/extensions_lib_stasis.conf
@@ -14,5 +14,5 @@ same  =          n,Stasis(callcontrol,relocate,${WAZO_RELOCATE_UUID},relocated)
 same  =          n,Hangup()
 
 exten = adhoc_conference,1,NoOp(User entering adhoc conference)
-same = n,Stasis(callcontrol,adhoc_conference,${WAZO_ADHOC_CONFERENCE_ID})
+same = n,Stasis(adhoc_conference,${WAZO_ADHOC_CONFERENCE_ID})
 same = n,Hangup()


### PR DESCRIPTION
## convert_to_stasis: add adhoc conference


## adhoc conference: rename stasis application

Why:

* Easier to separate events between applications
* Destruction events are hard to interpret correctly without an explicit
application