### PR TITLE
disable slave: use wazo services

### DIFF
--- a/sbin/xivo-manage-slave-services
+++ b/sbin/xivo-manage-slave-services
@@ -46,7 +46,7 @@ enable_service() {
 }
 
 disable_service() {
-    wazo-service stop xivo
+    wazo-service stop wazo
     wazo-service disable
     set_berofos_to_master_state
     stop_dhcp


### PR DESCRIPTION
Why:

* Using xivo services prints a warning that gets emailed by the slave
cron job