### PR TITLE
[WP-100] Fix wake mobile on group calls using extension members

### DIFF
--- a/dialplan/asterisk/extensions_lib_user.conf
+++ b/dialplan/asterisk/extensions_lib_user.conf
@@ -44,7 +44,7 @@ same  =   n,Gotoif(${XIVO_CALLRECORDFILE}?:$[${PRIORITY} + 2])
 same  =   n,MixMonitor(${XIVO_CALLRECORDFILE})
 same  =   n,GotoIf(${XIVO_ENABLEDND}?DND,1)
 same  =   n,GotoIf(${XIVO_ENABLEUNC}?UNC,1)
-same  =   n,GotoIf(${XIVO_REAL_FROMGROUP}?dial_from_group,1)
+same  =   n,GotoIf(${XIVO_REAL_FROMGROUP}?dial)
 same  =   n,GotoIf($[${GROUP_COUNT(${XIVO_DSTID}@XIVO_USER)} >= ${XIVO_SIMULTCALLS}]?BUSY,1)
 same  =   n,Set(OUTBOUND_GROUP_ONCE=${XIVO_DSTID}@XIVO_USER)
 
@@ -101,9 +101,6 @@ same  =                 n,GotoIf(${XIVO_ENABLEUNC}?busy)
 same  =                 n,Dial(${XIVO_INTERFACE},,${XIVO_CALLOPTIONS})
 same  =                 n(busy),Busy()
 same  =                 n,Return()
-
-exten = dial_from_group,1,Dial(${XIVO_INTERFACE},${XIVO_RINGSECONDS},${XIVO_CALLOPTIONS})
-same  =                 n,Goto(${DIALSTATUS},1)
 
 exten = forward_voicemail,1,NoOp()
 same  =   n,CELGenUserEvent(XIVO_USER_FWD,NUM:${XIVO_DST_USERNUM},CONTEXT:${WAZO_DST_USER_CONTEXT},NAME:${XIVO_DST_REDIRECTING_NAME})


### PR DESCRIPTION
the only difference between dial_from_group and dial is that dial going to dial
will launch the userevent that triggers the wake mobile. I removed
dial_from_group to avoid duplication