### PR TITLE
fix module configuration order

### DIFF
--- a/sbin/xivo-update-config
+++ b/sbin/xivo-update-config
@@ -137,7 +137,7 @@ BASE_RESULT_DIR=$(mktemp -d)
 
 LIST1=$(cd ${BASE_TEMPLATE_DIR}; find . -mindepth 1 -maxdepth 1 -type d -printf "%P\n")
 LIST2=$(cd ${CUSTOM_TEMPLATE_DIR}; find . -mindepth 1 -maxdepth 1 -type d -printf "%P\n")
-LIST=$(echo "${LIST1} ${LIST2}" | sort | uniq)
+LIST=$(echo -e "${LIST1}\n${LIST2}" | sort | uniq)
 
 for P in ${LIST}; do
   if [ -f ${BASE_TEMPLATE_DIR}/${P}.skip -o -f ${CUSTOM_TEMPLATE_DIR}/${P}.skip ]; then


### PR DESCRIPTION
Why:

* Given I have a custom template mail
* When I xivo-update-config
* Then xivo-update-config updates modules in order:

dhcp
mail
system
mail

Expected: it updates modules in order

dhcp
mail
system

Depending on the order of the output of find (depending on the last
update of the directories), we can have:
LIST1=dhcp
mail
system
LIST2=mail
LIST=dhcp
mail
system mail

This happens because the two \n-separated lists are joined with a space.