### PR TITLE
WAZO-976 conferences: add a prefix to conference ID

### DIFF
--- a/dialplan/asterisk/extensions_lib_conference.conf
+++ b/dialplan/asterisk/extensions_lib_conference.conf
@@ -1,5 +1,4 @@
-; XIVO Dialplan
-; Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+; Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 ; SPDX-License-Identifier: GPL-2.0+
 
 ; params:
@@ -20,5 +19,5 @@ same  =   n,Gosub(originate-caller-id,s,1)
 same  =   n,Set(CONFBRIDGE(bridge,template)=${WAZO_CONFBRIDGE_BRIDGE_PROFILE})
 same  =   n,Set(CONFBRIDGE(bridge,record_file)=/var/lib/wazo/sounds/tenants/${WAZO_CONFBRIDGE_TENANT_UUID}/monitor/conference-${WAZO_CONFBRIDGE_ID}.wav)
 same  =   n,Set(CONFBRIDGE(user,template)=${WAZO_CONFBRIDGE_USER_PROFILE})
-same  =   n,ConfBridge(${WAZO_CONFBRIDGE_ID},,,${WAZO_CONFBRIDGE_MENU})
+same  =   n,ConfBridge(wazo-conference-${WAZO_CONFBRIDGE_ID},,,${WAZO_CONFBRIDGE_MENU})
 same  =   n,Hangup()


### PR DESCRIPTION
this prefix will be used to distinguish between configured conference rooms and
dynamic ones created by pagings