### PR TITLE
user: make ARG2 of user more dynamic

### DIFF
--- a/dialplan/asterisk/extensions_lib_user.conf
+++ b/dialplan/asterisk/extensions_lib_user.conf
@@ -3,11 +3,13 @@
 
 ; params:
 ;  1 userfeatures ID
-;  2 dial timeout (ringtime)
+;  2 dial timeout (ringtime;moh_uuid)
 ;  3 extension ID (optional)
 [user]
 ; PRIORITY OF XIVO_DSTID= MUST BE 1 ; DON'T MODIFY
 exten = s,1,Set(XIVO_DSTID=${ARG1})
+same  =   n,Set(WAZO_RING_TIME=${SHIFT(ARG2,\;)})
+same  =   n,Set(WAZO_USER_MOH_UUID=${SHIFT(ARG2,\;)})
 same  =   n,Set(XIVO_DST_EXTEN_ID=${ARG3})
 same  =   n,Set(XIVO_PRESUBR_GLOBAL_NAME=USER)
 same  =   n,Set(CC_EXTEN=${XIVO_BASE_EXTEN})
@@ -36,7 +38,7 @@ same  =   n,GotoIf($["${XIVO_SCHEDULE_STATUS}" = "closed"]?CLOSED,1)
 
 same  =   n,Gosub(xivo-ring_type_set,s,1)
 same  =   n,GoSub(xivo-subroutine,s,1(${XIVO_USERPREPROCESS_SUBROUTINE}))
-same  =   n,Set(XIVO_RINGSECONDS=${IF($["${ARG2}" != ""]?${ARG2}:${XIVO_RINGSECONDS})})
+same  =   n,Set(XIVO_RINGSECONDS=${IF($["${WAZO_RING_TIME}" != ""]?${WAZO_RING_TIME}:${XIVO_RINGSECONDS})})
 same  =   n,Gosub(xivo-user_rights_check,s,1)
 same  =   n,GotoIf(${XIVO_REAL_FROMQUEUE}?dial_from_queue,1)
 same  =   n,GotoIf($["${XIVO_CALLFILTER}" = "1"]?xivo-user_callfilter,s,1)


### PR DESCRIPTION
ARG2 can now contain the ringtime as well as a MOH UUID, positions are important
here. If the ringtime is undefined ARG2 SHOULD be ";moh_uuid"

the AGI incoming_user_set_features is then responsible for finding the MOH based
on the UUID and add the "m" option for the "Dial" application.