### PR TITLE
Wazo 2353 Added a UserEvent when a caller hangs up the call he made himself

### DIFF
--- a/dialplan/asterisk/extensions_lib_user.conf
+++ b/dialplan/asterisk/extensions_lib_user.conf
@@ -69,7 +69,7 @@ same  =     n,Goto(forward_voicemail,1)
 
 exten = ANSWER,1,Hangup()
 
-exten = CANCEL,1,Hangup()
+exten = h,1,Gosub(notify-missed-call,1(cancel))
 
 exten = INVALIDARGS,1,Hangup()
 


### PR DESCRIPTION
Using the channel variable DIALSTATUS 'Cancel' which occurs when it
reached its number but the caller hung up before the recipient picked up.