### PR TITLE
usersharedlines: send the mobile push

### DIFF
--- a/dialplan/asterisk/extensions_lib_user.conf
+++ b/dialplan/asterisk/extensions_lib_user.conf
@@ -233,6 +233,7 @@ same  =      n,Hangup()
 [usersharedlines]
 ; exten should be a user UUID
 exten = _[0-9a-f].,1,AGI(agi://${XIVO_AGID_IP}/get_user_interfaces,${EXTEN})
+same  = n,AGI(agi://${XIVO_AGID_IP}/wake_mobile)
 same  = n,Dial(${WAZO_USER_INTERFACES})
 same  = n,Hangup
 

--- a/dialplan/asterisk/extensions_lib_user.conf
+++ b/dialplan/asterisk/extensions_lib_user.conf
@@ -54,7 +54,7 @@ same  =   n,Gosub(xivo-global-subroutine,s,1)
 same  =   n,Gosub(originate-caller-id,s,1)
 same  =   n,GotoIf(${WAZO_AUTO_ANSWER}?:dial)
 same  =   n,GoSub(paging,add-sip-headers,1)
-same  =   n(dial),AGI(agi://${XIVO_AGID_IP}/wake_mobile)
+same  =   n(dial),AGI(agi://${XIVO_AGID_IP}/wake_mobile,${WAZO_DST_UUID})
 same  =   n,GoSub(wazo-schedule-pre-dial-hooks,s,1)
 same  =   n,Dial(${XIVO_INTERFACE},${XIVO_RINGSECONDS},${XIVO_CALLOPTIONS})
 same  =   n,Goto(${DIALSTATUS},1)
@@ -233,7 +233,7 @@ same  =      n,Hangup()
 [usersharedlines]
 ; exten should be a user UUID
 exten = _[0-9a-f].,1,AGI(agi://${XIVO_AGID_IP}/get_user_interfaces,${EXTEN})
-same  = n,AGI(agi://${XIVO_AGID_IP}/wake_mobile)
+same  = n,AGI(agi://${XIVO_AGID_IP}/wake_mobile,${EXTEN})
 same  = n,Dial(${WAZO_USER_INTERFACES})
 same  = n,Hangup
 


### PR DESCRIPTION
changes in the AGI will now add the "Local/<aor>@wait-for-registration"
interface to the dial application. The only missing part is to actually send the
event that will trigger the phone to wake up.