### PR TITLE
Pull request for WAZO-2518-meetings

### DIFF
--- a/dialplan/asterisk/extensions_lib_meeting.conf
+++ b/dialplan/asterisk/extensions_lib_meeting.conf
@@ -1,0 +1,6 @@
+[wazo-meeting]
+exten = participant,1,NoOp(New participant in the meeting)
+same = n,Set(CONFBRIDGE(bridge,template)=wazo-meeting-bridge-profile)
+same = n,Set(CONFBRIDGE(user,template)=wazo-meeting-user-profile)
+same = n,ConfBridge(wazo-meeting-${WAZO_MEETING_UUID}-confbridge,,,wazo-meeting-menu)
+same = n,Hangup()


### PR DESCRIPTION
## usersharedlines: send the mobile push

changes in the AGI will now add the "Local/<aor>@wait-for-registration"
interface to the dial application. The only missing part is to actually send the
event that will trigger the phone to wake up.

## users: fix user UUID in AGI wake_mobile

Why:

* WAZO_DST_UUID is not set when calling from a group

## dialplan: add meetings