### PR TITLE
manage-slave-services: do not start services when already started

### DIFF
--- a/sbin/xivo-manage-slave-services
+++ b/sbin/xivo-manage-slave-services
@@ -1,6 +1,6 @@
 #!/bin/sh
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
-# SPDX-License-Identifier: GPL-3.0+
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 
@@ -37,6 +37,7 @@ stop_dhcp() {
 }
 
 enable_service() {
+    wazo-service status all >/dev/null && exit 0
     start_dhcp
     set_berofos_to_slave_state
     wazo-confgen asterisk/pjsip.conf --invalidate


### PR DESCRIPTION
`wazo-service status all` returns 0 when services are already started