### PR TITLE
meetings: fix caller id number

### DIFF
--- a/dialplan/asterisk/extensions_lib_meeting.conf
+++ b/dialplan/asterisk/extensions_lib_meeting.conf
@@ -2,7 +2,7 @@
 exten = participant,1,NoOp(New participant in the meeting)
 same = n,CELGenUserEvent(WAZO_MEETING_NAME,${WAZO_MEETING_NAME})
 same = n,Set(CONNECTEDLINE(name)=${WAZO_MEETING_NAME})
-same = n,Set(CONNECTEDLINE(number)=)
+same = n,Set(CONNECTEDLINE(number)=wazo-meeting-${WAZO_MEETING_UUID})
 same = n,Set(CONFBRIDGE(bridge,template)=wazo-meeting-bridge-profile)
 same = n,Set(CONFBRIDGE(user,template)=wazo-meeting-user-profile)
 same = n,ConfBridge(wazo-meeting-${WAZO_MEETING_UUID}-confbridge,,,wazo-meeting-menu)


### PR DESCRIPTION
Why:

* We want the extension in /calls peer_caller_id_number so that a user
can resync and know it is already calling this meeting.
* wazo-call-logd is already filtering out any wazo-meeting-.* from
callerid names.