### PR TITLE
WAZO-2577 meetings: add dialplan for the meeting participants

### DIFF
--- a/dialplan/asterisk/extensions_lib_meeting.conf
+++ b/dialplan/asterisk/extensions_lib_meeting.conf
@@ -1,3 +1,15 @@
+; Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+; SPDX-License-Identifier: GPL-2.0+
+
+[wazo-meeting-guest]
+exten = meeting-guest,1,NoOp(New guest participant in the meeting)
+same = n,Goto(wazo-meeting,participant,1)
+
+[wazo-meeting-user]
+exten = _wa[z]o-meeti[n]g-.,1,NoOp(New user participant in the meeting)
+same = n,AGI(agi://${XIVO_AGID_IP}/meeting_user,${EXTEN})
+same = n,Goto(wazo-meeting,participant,1)
+
 [wazo-meeting]
 exten = participant,1,NoOp(New participant in the meeting)
 same = n,CELGenUserEvent(WAZO_MEETING_NAME,${WAZO_MEETING_NAME})


### PR DESCRIPTION
guests have all the required variables set on the SIP endpoint
users will call the extension wazo-meeting-<uuid> the meeting_user AGI will
populate all required variables

Depends-On: https://github.com/wazo-platform/xivo-dao/pull/147/files
Depends-On: https://github.com/wazo-platform/wazo-agid/pull/79/files