### PR TITLE
context usersharedlines: add tT options to Dial()

### DIFF
--- a/dialplan/asterisk/extensions_lib_user.conf
+++ b/dialplan/asterisk/extensions_lib_user.conf
@@ -234,7 +234,7 @@ same  =      n,Hangup()
 ; exten should be a user UUID
 exten = _[0-9a-f].,1,AGI(agi://${XIVO_AGID_IP}/get_user_interfaces,${EXTEN})
 same  = n,AGI(agi://${XIVO_AGID_IP}/wake_mobile,${EXTEN})
-same  = n,Dial(${WAZO_USER_INTERFACES})
+same  = n,Dial(${WAZO_USER_INTERFACES},,tT)
 same  = n,Hangup
 
 [wazo_wait_for_registration]


### PR DESCRIPTION
I'm facing the following problem: a ring group rings, a member of the ring group answers and then we wants to transfer the call via DTMF (*2) => it doesn't work.

First, I figured out that, when calling Queue(), the options tT that allow to transfer via DTMF were not present. I added these options via a subroutine on the ring group:

```
[allowxferdtmf]
exten = s,1,NoOp(Allow transfer via DTMF)
same  =   n,Set(XIVO_GROUPOPTIONS=${XIVO_GROUPOPTIONS}Tt)
same  =   n,Return()
```

But it was still not working! I found out that, in the execution of the dialplan, after the Queue(), there was a Dial() in the context "usersharedlines" that didn't use the options tT. I added the options to this Dial() and I could eventually do the transfer via DTMF when getting the call via the ring group.