### PR TITLE
WAZO-2744 Asterisk WS reverse proxy: increase read timeout

### DIFF
--- a/etc/nginx/locations/https-available/asterisk
+++ b/etc/nginx/locations/https-available/asterisk
@@ -5,7 +5,7 @@ location = /api/asterisk/ws {
 
     proxy_pass http://127.0.0.1:5039/ws;
     proxy_http_version 1.1;
-    proxy_read_timeout 90s;
+    proxy_read_timeout 188s;  # twice the default SIP CRLF keep-alive + 8seconds
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
 }


### PR DESCRIPTION
Why:

* Asterisk has a default CRLF keep-alive of 90 seconds.
* In some scenarios (meetings), the Websocket is silent (one participant
muted), except for the keep-alive.
* This causes a race-condition between nginx and asterisk, where the WS
has 1:2 chances to be disconnected every 90 seconds.