### PR TITLE
WAZO-2854: convert_pre_dial_handler deprecated

### DIFF
--- a/dialplan/asterisk/extensions_lib_pre_dial.conf
+++ b/dialplan/asterisk/extensions_lib_pre_dial.conf
@@ -13,7 +13,7 @@ same = n,EndWhile()
 same = n,Return()
 
 [wazo-schedule-pre-dial-hooks]
-exten = s,1,AGI(agi://${XIVO_AGID_IP}/convert_pre_dial_handler)
+exten = s,1,AGI(agi://${XIVO_AGID_IP}/ignore_b_option)
 same = n,GotoIf(${WAZO_PRE_DIAL_HANDLERS}?:done)
 same = n,Set(XIVO_CALLOPTIONS=${XIVO_CALLOPTIONS}b(wazo-pre-dial-hooks^s^1))
 same = n(done),Return()


### PR DESCRIPTION
https://wazo-dev.atlassian.net/browse/WAZO-2854

the agid handler call is changed to `ignore_b_option` which just ignores any custom usage of the `b` option while logging a warning. 

Depends-On: https://github.com/wazo-platform/wazo-agid/pull/106
  