### PR TITLE
WP-866 caller id mapping for french local with international prefix

### DIFF
--- a/etc/xivo/asterisk/xivo_in_callerid.conf
+++ b/etc/xivo/asterisk/xivo_in_callerid.conf
@@ -29,7 +29,7 @@ add = 0
 
 [national4]
 comment = local number with international prefix, without "+" followed by 9 digits
-callerid = ^33[1-9]\d{9}$
+callerid = ^33[1-9]\d{8}$
 strip = 2
 add = 0
 

--- a/etc/xivo/asterisk/xivo_in_callerid.conf
+++ b/etc/xivo/asterisk/xivo_in_callerid.conf
@@ -27,6 +27,12 @@ callerid = ^\+33[1-9]\d{8}$
 strip = 3
 add = 0
 
+[national4]
+comment = local number with international prefix, without "+" followed by 9 digits
+callerid = ^33[1-9]\d{9}$
+strip = 2
+add = 0
+
 [international1]
 comment = international number, beginning with special digit "+" and at least 4 digits
 callerid = ^\+(?!33)\d{4,}$


### PR DESCRIPTION
https://wazo-dev.atlassian.net/browse/WP-866

* Added a configuration block to interpret french caller id number by stripping international prefix(assuming wazo stack is in french dialplan zone) 