### PR TITLE
WAZO-2858 HA check race condition

### DIFF
--- a/sbin/xivo-check-master-status
+++ b/sbin/xivo-check-master-status
@@ -2,15 +2,28 @@
 ip_addr=$1
 ping_count="3"
 ping_interval="10"
+confd_port=${CONFD_PORT:-9486}
+confd_version=${CONFD_API_VERSION:-1.1}
 
 if [ -z "$ip_addr" ]; then
     echo "usage: $(basename $0) ip_addr"
     exit 1
 fi
 
+check_ha_mode(){
+    local token=$(wazo-auth-cli token create --expiration 20)
+    curl -k -H "X-Auth-Token: $token" http://localhost:$confd_port/$confd_version/ha | jq -r .node_type
+}
+
 ping -c $ping_count -i $ping_interval $ip_addr
-if [ $? -eq 0 ]; then
-    /usr/sbin/xivo-manage-slave-services stop
+ping_status=$?
+if [ $(check_ha_mode) != "slave" ]; then
+    echo "HA mode changed, this slave has been freed!" >&2
+    exit 0
 else
-    /usr/sbin/xivo-manage-slave-services start
+    if [ $ping_status -eq 0 ]; then
+        /usr/sbin/xivo-manage-slave-services stop
+    else
+        /usr/sbin/xivo-manage-slave-services start
+    fi
 fi


### PR DESCRIPTION
https://wazo-dev.atlassian.net/browse/WAZO-2858

HA slave standby mechanism is vulnerable to race conditions when admin changes stack HA status out of slave mode.
A simple improvement is to check for the current HA mode right before acting on master status, which leaves less room for race conditions.