### PR TITLE
Disable star key on vm messages checking

### DIFF
--- a/dialplan/asterisk/extensions_lib_features.conf
+++ b/dialplan/asterisk/extensions_lib_features.conf
@@ -182,7 +182,7 @@ same  =   n,Goto(vmail,1)
 exten = vmail,1,Gosub(xivo-pickup,0,1)
 same  =       n,Set(TIMEOUT(absolute)=1800)
 same  =       n,Gosub(set_language,1)
-same  =       n,VoiceMail(${XIVO_MAILBOX}@${XIVO_MAILBOX_CONTEXT},u)
+same  =       n(voicemail-app),VoiceMail(${XIVO_MAILBOX}@${XIVO_MAILBOX_CONTEXT},u)
 same  =       n,Hangup()
 
 exten = set_language,1,NoOp()
@@ -194,10 +194,12 @@ same  =   n,Set(CHANNEL(language)=${IMPORT(${TRANSFERERNAME},CHANNEL(language))}
 same  =   n(end),Return()
 
 exten = a,1,Wait(1)
+same  =   n,GotoIf($["${WAZO_VM_PASSWORD}" = ""]?start-vm)
 same  =   n,GotoIf($["${XIVO_MAILBOX_LANGUAGE}" = ""]?$[${PRIORITY} + 2])
 same  =   n,Set(CHANNEL(language)=${XIVO_MAILBOX_LANGUAGE})
 same  =   n,VoiceMailMain(${XIVO_MAILBOX}@${XIVO_MAILBOX_CONTEXT})
 same  =   n,Hangup()
+same  =   n(start-vm),Goto(vmail,voicemail-app)
 
 exten = T,1,Hangup()
 

--- a/dialplan/asterisk/extensions_lib_user.conf
+++ b/dialplan/asterisk/extensions_lib_user.conf
@@ -141,7 +141,8 @@ same  =           n,Set(XIVO_VM_OPTIONS=${IF($["${XIVO_VM_OPTIONS}" = "b"]?b:u)}
 same  =           n,Set(TIMEOUT(absolute)=1800)
 same  =           n,GotoIf($["${XIVO_MAILBOX_LANGUAGE}" = ""]?$[${PRIORITY} + 2])
 same  =           n,Set(CHANNEL(language)=${XIVO_MAILBOX_LANGUAGE})
-same  =           n,Voicemail(${XIVO_MAILBOX}@${XIVO_MAILBOX_CONTEXT},${XIVO_VM_OPTIONS})
+same  =           n,AGI(agi://${XIVO_AGID_IP}/user_get_vmbox,${XIVO_DST_USERNUM})
+same  =           n(voicemail-app),Voicemail(${XIVO_MAILBOX}@${XIVO_MAILBOX_CONTEXT},${XIVO_VM_OPTIONS})
 same  =           n,Hangup()
 
 exten = set_voicemail_origin,1,Set(__XIVO_VOICEMAILVARS_ORIGIN=1)
@@ -176,7 +177,9 @@ same  = n,Return
 exten = T,1,Gosub(hangup,s,1)
 
 exten = a,1,Wait(1)
+same  =   n,GotoIf($["${WAZO_VM_PASSWORD}" = ""]?start-vm)
 same  =   n,VoiceMailMain(${XIVO_MAILBOX}@${XIVO_MAILBOX_CONTEXT})
+same  =   n(start-vm),Goto(voicemail,voicemail-app)
 
 [xivo-user_callfilter]
 exten = s,1,GotoIf(${XIVO_CALLFILTER_MODE}?:error,1)


### PR DESCRIPTION
If no password for the voicemail, the VoiceMail app is restarted again
If password provided, the VoiceMailMain app is allowed to start.

https://wiki.asterisk.org/wiki/display/AST/Application_VoiceMail

Linked with https://github.com/wazo-platform/wazo-agid/pull/115