### PR TITLE
remove infos table from the synchro

### DIFF
--- a/sbin/xivo-master-slave-db-replication
+++ b/sbin/xivo-master-slave-db-replication
@@ -14,6 +14,7 @@ EXCLUDE_TABLES='\
     -T cel_id_seq \
     -T dhcp \
     -T dhcp_id_seq \
+    -T infos \
     -T queue_log \
     -T queue_log_id_seq \
     -T session \


### PR DESCRIPTION
reason: we dont want to lost the uuid of the installation and the version