### PR TITLE
Add dependency on sqlalchemy-utils for dao

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ netaddr==0.7.19
 netifaces==0.10.9
 pyyaml==5.3.1  # from xivo-lib-python
 sqlalchemy==1.3.22  # from xivo-dao
+sqlalchemy-utils==0.36.8  # from xivo-dao


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-dao/pull/207