### PR TITLE
Fix dhcp configuration parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ netifaces==0.10.9
 pyyaml==5.3.1  # from xivo-lib-python
 sqlalchemy==1.3.22  # from xivo-dao
 sqlalchemy-utils==0.36.8  # from xivo-dao
+psycopg2-binary
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ netifaces==0.10.9
 pyyaml==5.3.1  # from xivo-lib-python
 sqlalchemy==1.3.22  # from xivo-dao
 sqlalchemy-utils==0.36.8  # from xivo-dao
-psycopg2-binary
+psycopg2-binary==2.8.6  # from xivo-dao
 

--- a/sbin/xivo-create-config
+++ b/sbin/xivo-create-config
@@ -69,7 +69,7 @@ def load_config_dhcp(session):
     net4_subnet = ''
 
     try:
-        main_iface = dhcp.network_interfaces.split(' ')[0]
+        main_iface = dhcp.network_interfaces.split(',')[0]
     except IndexError:
         main_iface = None
 

--- a/tests/test_xivo_create_config.py
+++ b/tests/test_xivo_create_config.py
@@ -17,7 +17,7 @@ def test_load_config_dhcp(ifaddresses):
         active = 1
         pool_start = '10.0.0.1'
         pool_end = '10.0.0.250'
-        network_interfaces = 'eth0'
+        network_interfaces = 'eth0,eth1'
 
     session = MockSession()
     ifaddresses.return_value = {
@@ -31,12 +31,14 @@ def test_load_config_dhcp(ifaddresses):
 
     result = xivo_create_config.load_config_dhcp(session)
 
+    ifaddresses.assert_called_with('eth0')
+
     assert_that(
         result,
         equal_to(
             {
                 'dhcp_active': 1,
-                'dhcp_network_interfaces': 'eth0',
+                'dhcp_network_interfaces': 'eth0,eth1',
                 'dhcp_pool': '10.0.0.1 10.0.0.250',
                 'dhcp_net4_ip': '10.0.0.254',
                 'dhcp_net4_netmask': '255.255.255.0',


### PR DESCRIPTION
Fix bug in xivo-create-config where `network_interfaces` field in `dhcp` table is expected to be a space-separated string, but data is actually saved by confd as comma-separated.