### PR TITLE
pickup: add a wazo-pickup subroutine

### DIFF
--- a/dialplan/asterisk/extensions_lib_features.conf
+++ b/dialplan/asterisk/extensions_lib_features.conf
@@ -325,6 +325,14 @@ same  =   n,Hangup()
 exten = error,1,NoOp(Invalid argument)
 same  =       n,Hangup()
 
+[wazo-pickup]
+exten = s,1,NoOp(Pickup ${ARG1}@${ARG2})
+same = n,Set(PICKUP_EXTEN=${ARG1})
+same = n,Set(PICKUP_CONTEXT=${ARG2})
+same = n,Stasis(dial_mobile,pickup,${PICKUP_EXTEN},${PICKUP_CONTEXT})
+same = n,Pickup(${PICKUP_EXTEN}%${PICKUP_CONTEXT}@PICKUPMARK)
+same = n,Hangup()
+
 [xivo-chk_feature_access]
 exten = s,1,GotoIf($["${XIVO_FWD_REFERER}" != ""]?$[${PRIORITY} + 2])
 same  =   n,Return()


### PR DESCRIPTION
The Pickup application does not work well with Stasis applications. Adding some dialplan around this application allows us to do specific routing before doing the Pickup.

In this case we are going to try to pickup the any dial_mobile that have been started on a AOR matching the PICKUPMARK we are picking up from.

Depends-On: https://github.com/wazo-platform/wazo-calld/pull/296