### PR TITLE
Pull request for WAZO-3244-use-systemctl

### DIFF
--- a/templates/dhcp.restart
+++ b/templates/dhcp.restart
@@ -3,7 +3,7 @@
 dhcpd-update -nri
 
 if [ "${XIVO_DHCP_ACTIVE}" = "1" ]; then
-  invoke-rc.d isc-dhcp-server restart
+  systemctl restart isc-dhcp-server
 else
-  invoke-rc.d isc-dhcp-server stop
+  systemctl stop isc-dhcp-server
 fi

--- a/templates/mail.restart
+++ b/templates/mail.restart
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 postmap /etc/postfix/canonical
-invoke-rc.d postfix restart
+systemctl restart postfix

--- a/templates/system.restart
+++ b/templates/system.restart
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-invoke-rc.d hostname.sh start


### PR DESCRIPTION
## remove non existing command

why: hostname.sh have been removed since systemd. This command do
nothing (silently fail)

## replace invoke-rc.d by systemctl