### PR TITLE
rename xivo-certs to wazo-certs

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Depends: fail2ban,
          python3-netifaces,
          python3,
          rename,
-         xivo-certs,
+         wazo-certs,
          wazo-dhcpd-update,
          xivo-utils
 Conflicts: asterisk-config

--- a/debian/xivo-config.dirs
+++ b/debian/xivo-config.dirs
@@ -1,4 +1,3 @@
 etc/nginx/locations/https-enabled
 etc/xivo/custom-templates
-usr/share/xivo-certs
 var/spool/asterisk/fax


### PR DESCRIPTION
* also remove unused directory. it has been migrated to xivo-certs long
  time ago