### PR TITLE
debian: remove wazo-certs dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,6 @@ Depends: fail2ban,
          python3-netifaces,
          python3,
          rename,
-         wazo-certs,
          wazo-dhcpd-update,
          xivo-utils
 Conflicts: asterisk-config


### PR DESCRIPTION
why: was used by old config, but not anymore