### PR TITLE
Pull request for WAZO-3599-remove-asterisk-fix

### DIFF
--- a/debian/xivo-config.postinst
+++ b/debian/xivo-config.postinst
@@ -73,6 +73,4 @@ esac
 
 #DEBHELPER#
 
-sed -i 's#/etc/pf-xivo#/etc/xivo#' /etc/xivo/asterisk/xivo_fax.conf
-
 exit 0

--- a/debian/xivo-config.postinst
+++ b/debian/xivo-config.postinst
@@ -9,9 +9,6 @@ case "$1" in
         odbcinst -i -s -f /usr/share/xivo-config/odbc/odbc.ini.template -l -v
         xivo-update-odbcinst-config
 
-        # run asterisk configuration
-        /usr/share/asterisk/bin/asterisk_fix
-
         # interaction with asterisk
         usermod -a -G www-data asterisk
         usermod -a -G asterisk www-data


### PR DESCRIPTION
## debian: remove old postinst migration


## remove call to asterisk_fix script

why: not used anymore, everything has been migrated to asterisk
packaging