### PR TITLE
dialplan: rename XIVO_ENABLE{FWD} to WAZO_ENABLE{FWD}

### DIFF
--- a/dialplan/asterisk/extensions_lib_features.conf
+++ b/dialplan/asterisk/extensions_lib_features.conf
@@ -80,7 +80,7 @@ same  =   n,Hangup()
 
 exten = feature,1,Gosub(xivo-pickup,0,1)
 same  =         n,AGI(agi://${WAZO_AGID_IP}/phone_get_features)
-same  =         n,Set(ENABLED=${XIVO_ENABLE${XIVO_FEATURE_FORWARD_UNAME}})
+same  =         n,Set(ENABLED=${WAZO_ENABLE${XIVO_FEATURE_FORWARD_UNAME}})
 same  =         n,GosubIf($[$["${ENABLED}" != "1"] & $["${XIVO_FEATURE_FORWARD_DEST}" = ""]]?readdigits,1)
 same  =         n,Set(TOGGLE=$[$["${ENABLED}" = "0"] | $[$["${XIVO_FEATURE_FORWARD_DEST}" != ""] & $["${XIVO_FEATURE_FORWARD_DEST}" != "${XIVO_DEST${XIVO_FEATURE_FORWARD_UNAME}}"]]])
 same  =         n,AGI(agi://${WAZO_AGID_IP}/phone_set_feature,${XIVO_FEATURE_FORWARD_LNAME},${TOGGLE},${XIVO_FEATURE_FORWARD_DEST})


### PR DESCRIPTION
why: this rename was missing from previous PR