### PR TITLE
remove unused DB credentials

### DIFF
--- a/debian/xivo-config.maintscript
+++ b/debian/xivo-config.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/xivo/datastorage.conf 24.02

--- a/etc/xivo/datastorage.conf
+++ b/etc/xivo/datastorage.conf
@@ -1,4 +1,0 @@
-[general]
-
-xivo = "postgresql://asterisk:proformatique@localhost/asterisk?encoding=utf8"
-asterisk = "postgresql://asterisk:proformatique@localhost/asterisk?charset=utf8"


### PR DESCRIPTION
why: was previously used by the old webi (<18.03)