### PR TITLE
Pull request for WAZO-3659-cleanup-maintenance

### DIFF
--- a/debian/xivo-config.cron.d
+++ b/debian/xivo-config.cron.d
@@ -1,3 +1,0 @@
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-
-*/5 *   * * *   root       xivo-check-long-calls

--- a/sbin/xivo-create-config
+++ b/sbin/xivo-create-config
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 import argparse
@@ -11,7 +11,6 @@ from jinja2 import Template
 from xivo_dao import default_config, init_db_from_config
 from xivo_dao.alchemy.dhcp import Dhcp
 from xivo_dao.alchemy.mail import Mail
-from xivo_dao.alchemy.monitoring import Monitoring
 from xivo_dao.alchemy.netiface import Netiface
 from xivo_dao.alchemy.provisioning import Provisioning
 from xivo_dao.alchemy.resolvconf import Resolvconf
@@ -51,7 +50,6 @@ def load_config():
         result.update(load_config_dhcp(session))
         result.update(load_config_smtp(session))
         result.update(load_config_provisioning(session))
-        result.update(load_config_monitoring(session))
         result.update(load_config_resolvconf(session))
         result.update(load_config_netiface(session))
         return result
@@ -129,28 +127,6 @@ def load_config_provisioning(session):
         'provd_http_port': str(provd.http_port),
         'provd_http_base_url': provd_url,
         'provd_dhcp_integration': '1',
-    }
-
-
-def load_config_monitoring(session):
-    monitoring = session.query(
-        Monitoring.maintenance,
-        Monitoring.alert_emails,
-        Monitoring.max_call_duration,
-    ).first()
-
-    return {
-        'maintenance': bool(monitoring.maintenance),
-        'alert_emails': (
-            monitoring.alert_emails.replace('\r\n', ' ')
-            if monitoring.alert_emails
-            else None
-        ),
-        'max_call_duration': (
-            str(monitoring.max_call_duration)
-            if monitoring.max_call_duration and monitoring.max_call_duration > 0
-            else None
-        ),
     }
 
 

--- a/sbin/xivo-read-config
+++ b/sbin/xivo-read-config
@@ -5,37 +5,6 @@
 [ -r /etc/xivo/common.conf ] && . /etc/xivo/common.conf
 
 
-_PF_EMAIL_ALERTS_LIST="pv-tech-client-alerts"
-
-
-create_pf_email_alerts()
-{
-  LIST_NAME=$1
-  SERVICE_NAME=$2
-
-  echo "${LIST_NAME}+${XIVO_HOSTNAME}+${SERVICE_NAME}@lists.proformatique.com"
-}
-
-get_full_email_alerts()
-{
-  SERVICE_NAME=$1
-
-  if [ "${PF_MAINTENANCE}" = "1" ]; then
-    EXTRA_EMAIL_ALERTS=$(create_pf_email_alerts ${_PF_EMAIL_ALERTS_LIST} ${SERVICE_NAME})
-  else
-    EXTRA_EMAIL_ALERTS=
-  fi
-
-  # xivo-sysconfd < 15.16 could generate a "None" XIVO_ALERT_EMAILS
-  if [ "${XIVO_ALERT_EMAILS}"  = "None" ]; then
-      XIVO_ALERT_EMAILS=""
-  fi
-
-  echo "${XIVO_ALERT_EMAILS} ${EXTRA_EMAIL_ALERTS}"
-}
-
-PRODUCT="XiVO"
-
 echo "Generating configuration"
 
 #### Set and check general variables ####
@@ -64,14 +33,6 @@ if [[ "${XIVO_DHCP_ACTIVE}" = "1" && -n "${XIVO_DHCP_POOL}" ]]; then
   _XIVO_DHCP_SUBNET="\# Include of the subnet declaration (DHCP is configured)\ninclude \"/etc/dhcp/dhcpd_subnet.conf\";"
 else
   _XIVO_DHCP_SUBNET="\# Subnet declaration not specified because DHCP is not configured\n\# Use dhcpd_extra.conf for custom configuration"
-fi
-
-if [ "${XIVO_MAINTENANCE}" = "1" ]; then
-  _PF_EMAIL_ALERTS_LIST="pv-tech-xivo-alerts"
-  _PF_EMAIL_ALERTS=$(create_pf_email_alerts ${_PF_EMAIL_ALERTS_LIST} "root")
-  _PF_EMAIL_REPORTS=$(create_pf_email_alerts "pv-tech-xivo-reports" "root")
-
-  XIVO_SMTP_CANONICAL="root\t${_PF_EMAIL_REPORTS}\nasterisk\t${_PF_EMAIL_REPORTS}"
 fi
 
 if [ -n "${XIVO_SMTP_MYDOMAIN}" ]; then

--- a/tests/test_xivo_create_config.py
+++ b/tests/test_xivo_create_config.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest.mock import Mock, patch
@@ -118,48 +118,6 @@ def test_load_config_provisioning():
                 'provd_http_base_url': 'http://localhost:8667',
                 'provd_http_port': '8667',
                 'provd_dhcp_integration': '1',
-            }
-        ),
-    )
-
-
-def test_load_config_monitoring():
-    class MockSession(Mock):
-        maintenance = 0
-        alert_emails = 'alice@example.com\r\nbob@example.com\r\ncharlie@example.com'
-        max_call_duration = 24
-
-    session = MockSession()
-    result = xivo_create_config.load_config_monitoring(session)
-
-    assert_that(
-        result,
-        equal_to(
-            {
-                'maintenance': False,
-                'alert_emails': 'alice@example.com bob@example.com charlie@example.com',
-                'max_call_duration': '24',
-            }
-        ),
-    )
-
-
-def test_load_config_monitoring_when_empty():
-    class MockSession(Mock):
-        maintenance = 0
-        alert_emails = ''
-        max_call_duration = 0
-
-    session = MockSession()
-    result = xivo_create_config.load_config_monitoring(session)
-
-    assert_that(
-        result,
-        equal_to(
-            {
-                'maintenance': False,
-                'alert_emails': None,
-                'max_call_duration': None,
             }
         ),
     )


### PR DESCRIPTION
## remove cron for check-long-calls

why: this script exit 0 if MAX_CALL_DURATION is unset and since 18.03
it's impossible to set this value. The script has been removed too

## remove monitoring logic

why: this logic is unusuable since 18.03 and now cause confusion