### PR TITLE
group-linear@group: reset interface variables after use

### DIFF
--- a/dialplan/asterisk/extensions_lib_group.conf
+++ b/dialplan/asterisk/extensions_lib_group.conf
@@ -76,6 +76,7 @@ same  =              n(loop),NoOp(Dialing members)
 
 same  =              n,GotoIf(${WAZO_GROUP_LINEAR_${i}_INTERFACE}?:waitretry)
 same  =              n,Dial(${WAZO_GROUP_LINEAR_${i}_INTERFACE},${WAZO_DIAL_TIMEOUT})
+same  =              n,Set(WAZO_GROUP_LINEAR_${i}_INTERFACE=)
 same  =              n,Set(i=$[${i} + 1])
 
 same  =              n(waitretry),Wait(${WAZO_GROUP_RETRY_DELAY})

--- a/dialplan/asterisk/extensions_lib_group.conf
+++ b/dialplan/asterisk/extensions_lib_group.conf
@@ -71,6 +71,8 @@ same  =              n,Set(__WAZO_FROMGROUPLINEAR=1)
 ; this is an infinite loop, this extension should be reached through a Dial with a timeout
 same  =              n(itermembers),AGI(agi://${WAZO_AGID_IP}/linear_group_get_interfaces,${WAZO_DSTID})
 same  =              n,Set(i=0)
+same  =              n,GotoIf($[${WAZO_GROUP_LINEAR_INTERFACE_COUNT} >= 1]?:waitretry)
+
 same  =              n,Set(__WAZO_DIAL_OPTIONS=${WAZO_GROUPOPTIONS})
 same  =              n(loop),NoOp(Dialing members)
 
@@ -80,7 +82,7 @@ same  =              n,Set(WAZO_GROUP_LINEAR_${i}_INTERFACE=)
 same  =              n,Set(i=$[${i} + 1])
 
 same  =              n(waitretry),Wait(${WAZO_GROUP_RETRY_DELAY})
-same  =              n,GotoIf(${WAZO_GROUP_LINEAR_${i}_INTERFACE}?loop:itermembers)
+same  =              n,GotoIf($[${i} < ${WAZO_GROUP_LINEAR_INTERFACE_COUNT}]?loop:itermembers)
 
 
 exten = TIMEOUT,1,Set(WAZO_FWD_TYPE=GROUP_NOANSWER)


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-agid/pull/174