### PR TITLE
dialplan outcall: allow setting external Diversion SIP header

### DIFF
--- a/dialplan/asterisk/extensions_lib_outcall.conf
+++ b/dialplan/asterisk/extensions_lib_outcall.conf
@@ -11,6 +11,7 @@ same  =   n,Set(WAZO_CONTEXT=${WAZO_BASE_CONTEXT})
 same  =   n,Set(WAZO_CHANNEL_DIRECTION=to-wazo)
 same  =   n,Set(__WAZO_CALL_DIRECTION=outbound)
 same  =   n,Gosub(originate-caller-id,s,1)
+same  =   n,Gosub(wazo-outcall-redirecting,s,1)
 same  =   n,AGI(agi://${WAZO_AGID_IP}/outgoing_user_set_features)
 same  =   n,GoSub(wazo-setup-userevent-dial-echo,s,1)
 same  =   n,GoSub(wazo-subroutine,s,1(${XIVO_OUTCALLPREPROCESS_SUBROUTINE}))
@@ -88,3 +89,10 @@ same  =   n,GotoIf(${WAZO_OUTCALL_PAI_NUMBER}?:done)
 same  =   n,Verbose(Using the trunk caller ID as a P-Asserted-Identity fallback)
 same  =   n(pai),Set(PJSIP_HEADER(add,P-Asserted-Identity)=tel:${WAZO_OUTCALL_PAI_NUMBER})
 same  =   n(done),Return()
+
+[wazo-outcall-redirecting]
+exten = s,1,NoOp
+same  =   n,GotoIf(${EXISTS(${WAZO_DST_REDIRECTING_EXTERN_NUM})}?:return)
+same  =   n,Set(REDIRECTING(from-num,i)=${WAZO_DST_REDIRECTING_EXTERN_NUM})
+same  =   n,Set(REDIRECTING(from-name,i)=${WAZO_DST_REDIRECTING_EXTERN_NAME})
+same  =   n(return),Return


### PR DESCRIPTION
Why:

* Operators expect Diversion header to contain a DID owned by the PBX
  sending the header