### PR TITLE
remove unused limits.d/asterisk.conf

### DIFF
--- a/etc/security/limits.d/asterisk.conf
+++ b/etc/security/limits.d/asterisk.conf
@@ -1,7 +1,0 @@
-# Rewrite by xivo-config because limit by default is to less for many call with Asterisk
-
-asterisk	soft	nofile	8192
-asterisk	hard	nofile	8192
-
-root		soft	nofile	8192
-root		hard	nofile	8192


### PR DESCRIPTION
why: this limit is already set in asterisk.service file
To validate this file has no impact:
`cat /proc/<pid asterisk>/limits`