### PR TITLE
Do not count calls if WAZO_USERID is missing

### DIFF
--- a/dialplan/asterisk/extensions_lib_conference.conf
+++ b/dialplan/asterisk/extensions_lib_conference.conf
@@ -17,8 +17,10 @@ same  =   n,Gosub(xivo-pickup,0,1)
 same  =   n,Gosub(wazo-global-subroutine,s,1)
 same  =   n,Gosub(originate-caller-id,s,1)
 
+same  =   n,GotoIf(${WAZO_USERID}?:no_userid)
 same  =   n,Gosub(callcounter,s,1(${WAZO_USERID}))
 same  =   n,GotoIf($[${GOSUB_RETVAL} = 1]?user,CANCEL,1)
+same  =   n(no_userid),NoOp(No WAZO_USERID, not counting calls)
 
 same  =   n,Set(CONFBRIDGE(bridge,template)=${WAZO_CONFBRIDGE_BRIDGE_PROFILE})
 same  =   n,Set(CONFBRIDGE(bridge,record_file)=/var/lib/wazo/sounds/tenants/${WAZO_CONFBRIDGE_TENANT_UUID}/monitor/conference-${WAZO_CONFBRIDGE_ID}.wav)

--- a/dialplan/asterisk/extensions_lib_group.conf
+++ b/dialplan/asterisk/extensions_lib_group.conf
@@ -24,8 +24,10 @@ same  =   n,NoOp(QSTATUS=${WAZO_SCHEDULE_STATUS})
 same  =   n,GotoIf($["${WAZO_SCHEDULE_STATUS}" = "closed"]?CLOSED,1)
 
 ; maximum calls for user
+same  =   n,GotoIf(${WAZO_USERID}?:no_userid)
 same  =   n,Gosub(callcounter,s,1(${WAZO_USERID}))
 same  =   n,GotoIf($[${GOSUB_RETVAL} = 1]?user,CANCEL,1)
+same  =   n(no_userid),NoOp(No WAZO_USERID, not counting calls)
 
 same  =   n,Gosub(wazo-ring_type_set,s,1)
 same  =   n,GoSub(wazo-subroutine,s,1(${XIVO_GROUPPREPROCESS_SUBROUTINE}))

--- a/dialplan/asterisk/extensions_lib_queue.conf
+++ b/dialplan/asterisk/extensions_lib_queue.conf
@@ -30,8 +30,10 @@ same  =   n,GotoIf($["${WAZO_SCHEDULE_STATUS}" = "closed"]?CLOSED,1)
 same  =   n,Set(_err=${QUEUE_VARIABLES(${WAZO_QUEUENAME})})
 
 ; maximum calls for user
+same  =   n,GotoIf(${WAZO_USERID}?:no_userid)
 same  =   n,Gosub(callcounter,s,1(${WAZO_USERID}))
 same  =   n,GotoIf($[${GOSUB_RETVAL} = 1]?user,CANCEL,1)
+same  =   n(no_userid),NoOp(No WAZO_USERID, not counting calls)
 
 ; queue statistics
 same  =   n,AGI(agi://${WAZO_AGID_IP}/check_diversion)


### PR DESCRIPTION
In the case of incalls to (queue, conference, group), there is no caller user ID and it is not possible to know the final destination until someone answers. Also, depending on the destination, it is only not possible to count because there are multiple users.