### PR TITLE
recording: add subroutine to record beep

### DIFF
--- a/dialplan/asterisk/extensions_lib_recording.conf
+++ b/dialplan/asterisk/extensions_lib_recording.conf
@@ -1,0 +1,17 @@
+; Copyright 2025 The Wazo Authors  (see the AUTHORS file)
+; SPDX-License-Identifier: GPL-2.0+
+
+[wazo-record-beep]
+exten = s,1,GotoIf(${WAZO_MIXMONITOR_FILENAME}?start)
+same = n,Verbose(3, ${CONTEXT} requires WAZO_MIXMONITOR_FILENAME to be set)
+same = n,Hangup()
+same = n(start),Set(WAZO_RECORD_SOUND_NAME=${IF(${EXISTS(${WAZO_RECORD_SOUND_NAME})}?${WAZO_RECORD_SOUND_NAME}:beep)})
+same = n,Answer()
+same = n,MixMonitor(${WAZO_MIXMONITOR_FILENAME},a${WAZO_MIXMONITOR_OPTIONS})
+same = n,Playback(${WAZO_RECORD_SOUND_NAME})
+same = n,Hangup()
+
+[wazo-record-listening-channel]
+exten = s,1,Answer()
+same = n,Wait(10)
+same = n,Hangup()


### PR DESCRIPTION
wazo-record-beep is a subroutine that will append to a recording and playback a sound file.

wazo-record-listening-channel is there to have a call to record.

These subroutines should be used by an originate looking like this

self._ari.channels.originate(
    endpoint='Local/s@wazo-record-listening-channel',
    context='wazo-record-beep',
    extension='s',
    priority='1',
    variables={'variables': {'WAZO_MIXMONITOR_FILENAME': filename}},
)