### PR TITLE
group: check for max calls before check for linear group

### DIFF
--- a/dialplan/asterisk/extensions_lib_group.conf
+++ b/dialplan/asterisk/extensions_lib_group.conf
@@ -46,7 +46,10 @@ same  =   n,Set(__WAZO_GROUP_SUBROUTINE=${XIVO_GROUPSUB})
 
 same  =   n(group),GotoIf(${WAZO_GROUPNAME}?:error-missing-group-name,s,1)
 same  =   n,GotoIf(${WAZO_GROUP_STRATEGY}?:error-missing-group-strategy,s,1)
-
+; limiting the number of calls
+same  =   n,Set(GROUP()=${WAZO_GROUPNAME})
+same  =   n,NoOp(Number of calls in group ${WAZO_GROUPNAME} = ${GROUP_COUNT(${WAZO_GROUPNAME})})
+same  =   n,GotoIf($[${GROUP_COUNT(${WAZO_GROUPNAME})} > ${WAZO_GROUP_MAX_CALLS}]?FULL,1)
 ; handle linear strategy through separate implementation
 same  =   n,GotoIf($["${WAZO_GROUP_STRATEGY}" == "linear"]?:queue)
 same  =   n,NoOp(Using alternative linear group implementation)
@@ -60,10 +63,6 @@ same  =   n,Set(__WAZO_GROUP_MAX_CALLS=${WAZO_GROUP_MAX_CALLS})
 
 same  =   n,GotoIf(${WAZO_GROUP_MAX_CALLS}?:linear)
 same  =   n,GotoIf($[${WAZO_GROUP_MAX_CALLS} > 0]?:linear)
-; limiting the number of calls
-same  =   n,Set(GROUP()=${WAZO_GROUPNAME})
-same  =   n,NoOp(Number of calls in group ${WAZO_GROUPNAME} = ${GROUP_COUNT(${WAZO_GROUPNAME})})
-same  =   n,GotoIf($[${GROUP_COUNT(${WAZO_GROUPNAME})} > ${WAZO_GROUP_MAX_CALLS}]?FULL,1)
 
 same  =   n(linear),Dial(Local/group-linear@group,${XIVO_GROUPTIMEOUT},${WAZO_GROUPOPTIONS})
 same  =   n,NoOp(Reached linear group timeout condition)


### PR DESCRIPTION
Why: if the group is not linear the check got skipped so the calls went through