### PR TITLE
add queue name event

### DIFF
--- a/dialplan/asterisk/extensions_lib_queue.conf
+++ b/dialplan/asterisk/extensions_lib_queue.conf
@@ -18,6 +18,7 @@ same  =   n,Set(__WAZO_FWD_REFERER=${IF(${EXISTS(${WAZO_FWD_REFERER})}?${WAZO_FW
 same  =   n,NoOp(PATH=${XIVO_PATH}/${XIVO_PATH_ID})
 same  =   n,Gosub(originate-caller-id,s,1)
 same  =   n,AGI(agi://${WAZO_AGID_IP}/incoming_queue_set_features)
+same  =   n,CELGenUserEvent(WAZO_CALL_LOG_DESTINATION,type: queue,id: ${WAZO_DSTID},name: ${WAZO_QUEUENAME})
 same  =   n,NoOp(PATH=${XIVO_PATH}/${XIVO_PATH_ID})
 
 ; schedule


### PR DESCRIPTION
This change will be used to be able to add queue name and id to CDR.
an update of wazo-call-logd is depending on this change.