### PR TITLE
[WAZO-4032] lib_recording: remove mixmonitor options in beep playback

### DIFF
--- a/dialplan/asterisk/extensions_lib_recording.conf
+++ b/dialplan/asterisk/extensions_lib_recording.conf
@@ -7,7 +7,7 @@ same = n,Verbose(3, ${CONTEXT} requires WAZO_MIXMONITOR_FILENAME to be set)
 same = n,Hangup()
 same = n(start),Set(WAZO_RECORD_SOUND_NAME=${IF(${EXISTS(${WAZO_RECORD_SOUND_NAME})}?${WAZO_RECORD_SOUND_NAME}:beep)})
 same = n,Answer()
-same = n,MixMonitor(${WAZO_MIXMONITOR_FILENAME},a${WAZO_MIXMONITOR_OPTIONS})
+same = n,MixMonitor(${WAZO_MIXMONITOR_FILENAME},a)
 same = n,Playback(${WAZO_RECORD_SOUND_NAME})
 same = n,Hangup()
 


### PR DESCRIPTION
Why: useless