### PR TITLE
[WP-1745] extensions_lib_outcall: use number@host format for PAI header

### DIFF
--- a/dialplan/asterisk/extensions_lib_outcall.conf
+++ b/dialplan/asterisk/extensions_lib_outcall.conf
@@ -87,7 +87,7 @@ same  =   n,GotoIf(${WAZO_OUTCALL_PAI_NUMBER}?pai:)
 same  =   n,Set(WAZO_OUTCALL_PAI_NUMBER=${CALLERID(num,${PJSIP_ENDPOINT(${CHANNEL(endpoint)},callerid)})})
 same  =   n,GotoIf(${WAZO_OUTCALL_PAI_NUMBER}?:done)
 same  =   n,Verbose(Using the trunk caller ID as a P-Asserted-Identity fallback)
-same  =   n(pai),Set(PJSIP_HEADER(add,P-Asserted-Identity)=tel:${WAZO_OUTCALL_PAI_NUMBER})
+same  =   n(pai),Set(PJSIP_HEADER(add,P-Asserted-Identity)=<${WAZO_OUTCALL_PAI_NUMBER}@${WAZO_TRUNK_HOST}>)
 same  =   n(done),Return()
 
 [wazo-outcall-redirecting]


### PR DESCRIPTION
Why: `tel:number` is not supported by most carriers