### PR TITLE
WAZO-4174-remove-server-name

### DIFF
--- a/templates/nginx/etc/nginx/sites-available/wazo-provd
+++ b/templates/nginx/etc/nginx/sites-available/wazo-provd
@@ -1,7 +1,7 @@
 server {
     listen #XIVO_PROVD_HTTP_PORT# default_server;
     listen [::]:#XIVO_PROVD_HTTP_PORT# default_server;
-    server_name $domain;
+    server_name _;
 
     access_log /var/log/nginx/wazo-provd.access.log main;
     error_log /var/log/nginx/wazo-provd.error.log;


### PR DESCRIPTION
why: $domain value was used by a regex captured group long time ago ...
Now the value is a plain "$domain" string which will never match a
valid domain
The standard syntax to use to have a catch-all is "_"
