### PR TITLE
queue: add a new CELGenUserEvent

### DIFF
--- a/dialplan/asterisk/extensions_lib_queue.conf
+++ b/dialplan/asterisk/extensions_lib_queue.conf
@@ -18,6 +18,7 @@ same  =   n,Set(__WAZO_FWD_REFERER=${IF(${EXISTS(${WAZO_FWD_REFERER})}?${WAZO_FW
 same  =   n,NoOp(PATH=${WAZO_PATH}/${WAZO_PATH_ID})
 same  =   n,Gosub(originate-caller-id,s,1)
 same  =   n,AGI(agi://${WAZO_AGID_IP}/incoming_queue_set_features)
+same  =   n,CELGenUserEvent(WAZO_CALL_LOG_REQUESTED_INTERNAL,type: queue,number: ${WAZO_REAL_NUMBER},context: ${WAZO_REAL_CONTEXT},tenant_uuid: ${WAZO_TENANT_UUID})
 same  =   n,NoOp(PATH=${WAZO_PATH}/${WAZO_PATH_ID})
 
 ; schedule


### PR DESCRIPTION
The goal of the event is to have the internal requested internal number and requested internal context when calling a Queue