### PR TITLE
TASK-248 agentd-cli-refactor

### DIFF
--- a/sbin/xivo-manage-slave-services
+++ b/sbin/xivo-manage-slave-services
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
@@ -34,7 +34,7 @@ enable_service() {
     wazo-confgen asterisk/pjsip.conf --invalidate
     wazo-service enable
     wazo-service start
-    wazo-agentd-cli -c 'relog all --timeout 60'
+    wazo-agentd-cli relog all --timeout 60
 }
 
 disable_service() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small change to a service-management shell script, mainly adjusting CLI invocation semantics; risk is limited to potential behavior differences in `wazo-agentd-cli relog` argument parsing.
> 
> **Overview**
> Updates `sbin/xivo-manage-slave-services` to reflect the `wazo-agentd-cli` refactor by switching from `-c 'relog …'` to direct `wazo-agentd-cli relog all --timeout 60` invocation when enabling slave services.
> 
> Also refreshes the script header copyright year range to 2026.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 141b0ac48998b9a9e1012454c179dd82d67d1527. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->